### PR TITLE
allow using custom axios implementation

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -7,6 +7,7 @@ interface ClusterOpts {
   uri?: string;
   auth?: AxiosBasicCredentials;
   cloud?: CloudOpts;
+  axiosLibrary?: typeof axios;
 }
 
 class Cluster {
@@ -19,7 +20,7 @@ class Cluster {
       baseURL = 'https://api.numary.cloud/ledger';
     }
 
-    this.conn = axios.create({
+    this.conn = (opts?.axiosLibrary ?? axios).create({
       baseURL,
       auth: opts.auth,
     });


### PR DESCRIPTION
This resembles what [Stripe did](https://github.com/stripe-samples/stripe-node-deno-samples/blob/main/checkout-integration/main.js) to enable support of Deno, and sorts out issues when trying to use `esm.sh`'s _axios_ library, that is raising issues with Deno (as previously mentioned on [Discord](https://discord.com/channels/846686859869814784/867013639084048414/1022664227644784662)).

While this change enables broader compatibility with Deno, it doesn't change the overall codebase itself, since it's just a dependency injection.